### PR TITLE
fix: 完善nodeIdentifier的生成判断以解决崩溃问题

### DIFF
--- a/SJMediaCacheServer/Core/Asset/HLS/HLSAsset.m
+++ b/SJMediaCacheServer/Core/Asset/HLS/HLSAsset.m
@@ -247,7 +247,7 @@ static NSString *HLS_AES_KEY_MIME_TYPE = @"application/octet-stream";
 
 /// @param byteRange #EXT-X-BYTERANGE or { NSNotFound, NSNotFound }
 - (NSString *)generateSegmentNodeIdentifierWithIdentifier:(NSString *)segmentIdentifier requestHeaderByteRange:(NSRange)byteRange {
-    return byteRange.location == NSNotFound ? segmentIdentifier : [NSString stringWithFormat:@"%@_%lu_%lu", segmentIdentifier, byteRange.location, byteRange.length];
+    return (byteRange.location == NSNotFound || byteRange.length == NSNotFound) ? segmentIdentifier : [NSString stringWithFormat:@"%@_%lu_%lu", segmentIdentifier, byteRange.location, byteRange.length];
 }
 
 #pragma mark - mark


### PR DESCRIPTION
在使用 `m3u8` 进行播放时遇到崩溃

<img width="1298" alt="image" src="https://github.com/user-attachments/assets/ab78cfb6-a865-4344-a610-43231ba5beb2" />

通过调用栈定位到，因生成错误的 `nodeIdentifier` 而无法从 `mSegmentItems` 中取到值，致 `item` 为 `nil`。

<img width="1718" alt="image" src="https://github.com/user-attachments/assets/0968f185-4da2-422a-9a35-8e76a17886ac" />

```
nodeIdentifier	__NSCFString *	@"0b62aeb8344fdc978b56ef6ba80ef9f6.ts_0_9223372036854775807"	0x0000000302cbdc70
```

```objc
static const NSInteger NSNotFound = NSIntegerMax;
```

根据 `NSNotFound` 的定义得知，其实际上是 `NSInteger` 的最大值:
- 在 `32` 位系统上是 `2147483647` (0x7fffffff)
- 在 `64` 位系统上是 `9223372036854775807` (0x7fffffffffffffff)

所以 `nodeIdentifier` 中的 `9223372036854775807` 是 `NSNotFound`，即此时的 `byteRange.length` 为 `NSNotFound`。

<img width="1075" alt="image" src="https://github.com/user-attachments/assets/0745437b-ff97-42f5-a0c5-f60336be58f1" />

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/23402338-f302-4708-823a-3cadf43005bf" />

上方两个截图的情况：
1. 当 `byteRange.location` 为 `NSNotFound`，一切正常
2. 但是有时会出现 `byteRange.location` 为 `0`，而 `byteRange.length` 为 `NSNotFound` 的情况，此时就会得到错误的 `nodeIdentifier`

综上，本 `PR` 对 `generateSegmentNodeIdentifierWithIdentifier` 进行完善，补充 `byteRange.length == NSNotFound` 的判断，以此来解决崩溃问题。